### PR TITLE
new middleman-sprockets version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gem 'middleman', '= 4.2'
 gem 'middleman-autoprefixer', '~> 2.7'
-gem 'middleman-sprockets'
+gem 'middleman-sprockets', '4.0.0.rc.3'
 gem 'middleman-deploy', git: 'https://github.com/lewagon/middleman-deploy.git'
 gem 'rack'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       servolux
       tilt (~> 2.0)
       uglifier (~> 3.0)
-    middleman-sprockets (4.1.1)
+    middleman-sprockets (4.0.0.rc.3)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
     minitest (5.14.2)
@@ -140,7 +140,7 @@ DEPENDENCIES
   middleman (= 4.2)
   middleman-autoprefixer (~> 2.7)
   middleman-deploy!
-  middleman-sprockets
+  middleman-sprockets (= 4.0.0.rc.3)
   puma
   rack
   rack-contrib


### PR DESCRIPTION
Specifies new version of `middleman-sprockets` and update `bundler`. Now css file is found again and working with `.scss` syntax