### PR TITLE
bumped old version of kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ gem 'rack-contrib'
 gem 'font-awesome-sass'
 gem 'bootstrap-sass'
 gem 'jquery-middleman'
-
+gem "kramdown", ">= 2.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     i18n (0.7.0)
     jquery-middleman (3.1.2)
       thor (>= 0.14, < 2.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -57,7 +57,7 @@ GEM
       coffee-script (~> 2.2)
       compass-import-once (= 1.0.5)
       haml (>= 4.0.5)
-      kramdown (~> 1.2)
+      kramdown (>= 1.2)
       middleman-cli (= 4.2.0)
       middleman-core (= 4.2.0)
       sass (>= 3.4.0, < 4.0)
@@ -137,6 +137,7 @@ DEPENDENCIES
   bootstrap-sass
   font-awesome-sass
   jquery-middleman
+  kramdown (>= 2.3.0)
   middleman (= 4.2)
   middleman-autoprefixer (~> 2.7)
   middleman-deploy!


### PR DESCRIPTION
The kramdown gem before 2.3.0 for Ruby processes the template option inside Kramdown documents by default, which allows unintended read access (such as template="/etc/passwd") or unintended embedded Ruby code execution (such as a string that begins with template="string://<%= `).